### PR TITLE
Add the clj command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ RUN mkdir -p $LEIN_INSTALL \
   && mkdir -p /usr/share/java \
   && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
 
+RUN curl -O https://download.clojure.org/install/linux-install-1.10.1.447.sh \
+  && chmod +x linux-install-1.10.1.447.sh \
+  && ./linux-install-1.10.1.447.sh
+
 ENV PATH=$PATH:$LEIN_INSTALL
 ENV LEIN_ROOT 1
 


### PR DESCRIPTION
@codeasone can I get your help with this?  I'm trying to add the clojure `clj` command line tool.  I added these commands based off the info [here](https://www.clojure.org/guides/getting_started#_installation_on_linux).

However, when I try to build locally I get the following error - it's failing before it even gets to the bit I added:
```
Hit:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package oracle-java8-installer is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'oracle-java8-installer' has no installation candidate
The command '/bin/sh -c apt-get update &&     apt-get upgrade -y &&     apt-get install -y software-properties-common &&     add-apt-repository ppa:webupd8team/java -y &&     apt-get update &&     echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections &&     apt-get install -y oracle-java8-installer &&     apt-get clean' returned a non-zero code: 100
```
